### PR TITLE
Replace gateway ID with Region enum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bw-web-api",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bw-web-api",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "dependencies": {
         "zod": "^3.21.4"
       },

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -61,6 +61,14 @@ export type AuroraProfileByToonV2FieldMask =
   | "scr_tooninfo"
   | "scr_profile";
 
+export enum Region {
+  USWest = 10,
+  USEast = 11,
+  Europe = 20,
+  Korea = 30,
+  Asia = 45,
+}
+
 export interface ISCApi {
   classicFilesGlobalMaps1v1: () => Promise<ClassicFilesGlobalMaps1v1Response>;
   gateway: () => Promise<GatewayResponse>;
@@ -77,15 +85,15 @@ export interface ISCApi {
   leaderboardRankByToon: (
     ladder: number,
     toon: string,
-    gateway: number
+    gateway: Region
   ) => Promise<LeaderboardRankByToonResponse>;
   mapStatsByToon: (
     toon: string,
-    gateway: number
+    gateway: Region
   ) => Promise<MapStatsByToonResponse>;
   matchMakerGameInfoByToon: (
     toon: string,
-    gateway: number,
+    gateway: Region,
     gameMode: number,
     season: number,
     offset: number,
@@ -96,7 +104,7 @@ export interface ISCApi {
   ) => Promise<MatchMakerGameInfoPlayerInfoResponse>;
   auroraProfileByToon: (
     toon: string,
-    gateway: number,
+    gateway: Region,
     mask: AuroraProfileByToonV2FieldMask
   ) => Promise<
     | AuroraProfileByToonScrMmGameLoadingResponse
@@ -161,7 +169,7 @@ export class SCApi implements ISCApi {
   leaderboardRankByToon = async (
     ladder: number,
     toon: string,
-    gateway: number
+    gateway: Region
   ): Promise<LeaderboardRankByToonResponse> =>
     await this.schemaFetch(
       LeaderboardRankByToonResponseSchema,
@@ -175,7 +183,7 @@ export class SCApi implements ISCApi {
 
   mapStatsByToon = async (
     toon: string,
-    gateway: number
+    gateway: Region
   ): Promise<MapStatsByToonResponse> =>
     await this.schemaFetch(
       MapStatsByToonResponseSchema,
@@ -184,7 +192,7 @@ export class SCApi implements ISCApi {
 
   matchMakerGameInfoByToon = async (
     toon: string,
-    gateway: number,
+    gateway: Region,
     gameMode: number,
     season: number,
     offset = 0,
@@ -207,7 +215,7 @@ export class SCApi implements ISCApi {
 
   auroraProfileByToon = async (
     toon: string,
-    gateway: number,
+    gateway: Region,
     mask: AuroraProfileByToonV2FieldMask
   ): Promise<
     | AuroraProfileByToonScrMmGameLoadingResponse

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,4 +1,4 @@
-import { SCApi } from "@/api";
+import { Region, SCApi } from "@/api";
 import { BroodWarConnection } from "@/bw-connection";
 import { readFile } from "fs/promises";
 import { assert, describe, it, vi } from "vitest";
@@ -37,7 +37,7 @@ describe("SCApi", () => {
   });
 
   it("can fetch and parse the leaderboard rank by toon API response", async () => {
-    await api.leaderboardRankByToon(1, "bob", 10);
+    await api.leaderboardRankByToon(1, "bob", Region.USWest);
   });
 
   it("can fetch and parse the leaderboard API response", async () => {
@@ -45,12 +45,12 @@ describe("SCApi", () => {
   });
 
   it("can fetch and parse the map stats by toon API response", async () => {
-    const stats = await api.mapStatsByToon("bob", 10);
+    const stats = await api.mapStatsByToon("bob", Region.USWest);
     assert(stats.map_stat);
   });
 
   it("can fetch and parse the match maker game info by toon API response", async () => {
-    await api.matchMakerGameInfoByToon("bob", 10, 1, 1);
+    await api.matchMakerGameInfoByToon("bob", Region.USWest, 1, 1);
   });
 
   it("can fetch and parse the match maker player info API response", async () => {
@@ -58,18 +58,18 @@ describe("SCApi", () => {
   });
 
   it("can fetch and parse the aurora profile by toon with scr_mmgameloading mask API response", async () => {
-    await api.auroraProfileByToon("bob", 10, "scr_mmgameloading");
+    await api.auroraProfileByToon("bob", Region.USWest, "scr_mmgameloading");
   });
 
   it("can fetch and parse the aurora profile by toon with scr_mmtooninfo mask API response", async () => {
-    await api.auroraProfileByToon("bob", 10, "scr_mmtooninfo");
+    await api.auroraProfileByToon("bob", Region.USWest, "scr_mmtooninfo");
   });
 
   it("can fetch and parse the aurora profile by toon with scr_profile mask API response", async () => {
-    await api.auroraProfileByToon("bob", 10, "scr_profile");
+    await api.auroraProfileByToon("bob", Region.USWest, "scr_profile");
   });
 
   it("can fetch and parse the aurora profile by toon with scr_tooninfo mask API response", async () => {
-    await api.auroraProfileByToon("bob", 10, "scr_tooninfo");
+    await api.auroraProfileByToon("bob", Region.USWest, "scr_tooninfo");
   });
 });


### PR DESCRIPTION
## Summary
 This PR adds a `Region` enum that maps regions to the corresponding gateway ID and updates the function signatures to use `Region` instead of `number`.

## Changes
- Defined a new `Region` enum mapping regions to their corresponding IDs.
- Updated function signatures to use the `Region` enum instead of `number` for the `gateway` parameter.
- Updated unit tests to reflect these changes.

Let me know if there are any further changes or adjustments you'd like.